### PR TITLE
Extend raw resource domain support

### DIFF
--- a/server/routers/resource/updateResource.ts
+++ b/server/routers/resource/updateResource.ts
@@ -93,12 +93,23 @@ const updateRawResourceBodySchema = z
         name: z.string().min(1).max(255).optional(),
         proxyPort: z.number().int().min(1).max(65535).optional(),
         stickySession: z.boolean().optional(),
-        enabled: z.boolean().optional()
+        enabled: z.boolean().optional(),
+        domainId: z.string().optional(),
+        subdomain: z.string().nullable().optional()
     })
     .strict()
     .refine((data) => Object.keys(data).length > 0, {
         message: "At least one field must be provided for update"
     })
+    .refine(
+        (data) => {
+            if (data.subdomain) {
+                return subdomainSchema.safeParse(data.subdomain).success;
+            }
+            return true;
+        },
+        { message: "Invalid subdomain" }
+    )
     .refine(
         (data) => {
             if (!config.getRawConfig().flags?.allow_raw_resources) {
@@ -411,6 +422,115 @@ async function updateRawResource(
                     "Resource with that protocol and port already exists"
                 )
             );
+        }
+    }
+
+    if (updateData.domainId !== undefined || updateData.subdomain !== undefined) {
+        const domainId = updateData.domainId ?? resource.domainId;
+
+        if (domainId) {
+            const [domainRes] = await db
+                .select()
+                .from(domains)
+                .where(eq(domains.domainId, domainId))
+                .leftJoin(
+                    orgDomains,
+                    and(
+                        eq(orgDomains.orgId, resource.orgId),
+                        eq(orgDomains.domainId, domainId)
+                    )
+                );
+
+            if (!domainRes || !domainRes.domains) {
+                return next(
+                    createHttpError(
+                        HttpCode.NOT_FOUND,
+                        `Domain with ID ${domainId} not found`
+                    )
+                );
+            }
+
+            if (
+                domainRes.orgDomains &&
+                domainRes.orgDomains.orgId !== resource.orgId
+            ) {
+                return next(
+                    createHttpError(
+                        HttpCode.FORBIDDEN,
+                        `You do not have permission to use domain with ID ${domainId}`
+                    )
+                );
+            }
+
+            if (!domainRes.domains.verified) {
+                return next(
+                    createHttpError(
+                        HttpCode.BAD_REQUEST,
+                        `Domain with ID ${domainId} is not verified`
+                    )
+                );
+            }
+
+            const subdomain =
+                updateData.subdomain !== undefined
+                    ? updateData.subdomain
+                    : resource.subdomain ?? undefined;
+
+            let fullDomain = "";
+            if (domainRes.domains.type == "ns") {
+                if (subdomain) {
+                    fullDomain = `${subdomain}.${domainRes.domains.baseDomain}`;
+                } else {
+                    fullDomain = domainRes.domains.baseDomain;
+                }
+            } else if (domainRes.domains.type == "cname") {
+                fullDomain = domainRes.domains.baseDomain;
+            } else if (domainRes.domains.type == "wildcard") {
+                if (subdomain !== undefined) {
+                    const parsedSubdomain = subdomainSchema.safeParse(subdomain);
+                    if (!parsedSubdomain.success) {
+                        return next(
+                            createHttpError(
+                                HttpCode.BAD_REQUEST,
+                                fromError(parsedSubdomain.error).toString()
+                            )
+                        );
+                    }
+                    fullDomain = `${subdomain}.${domainRes.domains.baseDomain}`;
+                } else {
+                    fullDomain = domainRes.domains.baseDomain;
+                }
+            }
+
+            fullDomain = fullDomain.toLowerCase();
+
+            const [existingDomain] = await db
+                .select()
+                .from(resources)
+                .where(eq(resources.fullDomain, fullDomain));
+
+            if (
+                existingDomain &&
+                existingDomain.resourceId !== resource.resourceId
+            ) {
+                return next(
+                    createHttpError(
+                        HttpCode.CONFLICT,
+                        "Resource with that domain already exists"
+                    )
+                );
+            }
+
+            if (fullDomain && fullDomain !== resource.fullDomain) {
+                await db
+                    .update(resources)
+                    .set({ fullDomain })
+                    .where(eq(resources.resourceId, resource.resourceId));
+            }
+
+            if (fullDomain === domainRes.domains.baseDomain) {
+                updateData.subdomain = null;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow `domainId` and `subdomain` fields in raw resource updates
- compute `fullDomain` when domain data changes and avoid duplicates

## Testing
- `npm run db:sqlite:generate`
- `npm run db:sqlite:push`
- `npm run build:sqlite`
- `npm run build:cli`
- `make build-sqlite` *(fails: docker not found)*
- `make build-pg` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d0efd5fc832583dbb675bf68e811