### PR TITLE
Improve HostSNI rule generation

### DIFF
--- a/server/routers/traefik/getTraefikConfig.ts
+++ b/server/routers/traefik/getTraefikConfig.ts
@@ -382,7 +382,15 @@ export async function traefikConfigProvider(
                 config_output[protocol].routers[routerName] = {
                     entryPoints: [`${protocol}-${port}`],
                     service: serviceName,
-                    ...(protocol === "tcp" ? { rule: "HostSNI(`*`)" } : {})
+                    ...(protocol === "tcp"
+                        ? {
+                              rule: `HostSNI(${
+                                  resource.fullDomain
+                                      ? `\`${resource.fullDomain}\``
+                                      : "`*`"
+                              })`
+                          }
+                        : {})
                 };
 
                 config_output[protocol].services[serviceName] = {


### PR DESCRIPTION
## Summary
- support HostSNI rules based on resource domains

## Testing
- `npm run build:sqlite`
- `npm run build:cli`
- `make build-sqlite` *(fails: Cannot connect to the Docker daemon)*
- `make build-pg` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688448924e7c83258cea9b4049f0b886