### PR TITLE
Add domain picker support for raw resources

### DIFF
--- a/src/app/[orgId]/settings/resources/[resourceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/resources/[resourceId]/general/page.tsx
@@ -120,7 +120,7 @@ export default function GeneralForm() {
 
     const GeneralFormSchema = z.object({
         enabled: z.boolean(),
-        subdomain: z.string().optional(),
+        subdomain: subdomainSchema.optional(),
         name: z.string().min(1).max(255),
         domainId: z.string().optional(),
         proxyPort: z.number().int().min(1).max(65535).optional()
@@ -351,6 +351,37 @@ export default function GeneralForm() {
 
                                         {!resource.http && (
                                             <>
+                                                <DomainPicker
+                                                    orgId={orgId as string}
+                                                    onDomainChange={(res) => {
+                                                        form.setValue(
+                                                            "subdomain",
+                                                            res.subdomain
+                                                        );
+                                                        form.setValue(
+                                                            "domainId",
+                                                            res.domainId
+                                                        );
+                                                    }}
+                                                />
+                                                <FormField
+                                                    control={form.control}
+                                                    name="subdomain"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <FormLabel>
+                                                                {t("subdomain")}
+                                                            </FormLabel>
+                                                            <FormControl>
+                                                                <Input {...field} />
+                                                            </FormControl>
+                                                            <FormMessage />
+                                                            <FormDescription>
+                                                                {t("subdomnainDescription")}
+                                                            </FormDescription>
+                                                        </FormItem>
+                                                    )}
+                                                />
                                                 <FormField
                                                     control={form.control}
                                                     name="proxyPort"

--- a/src/app/[orgId]/settings/resources/create/page.tsx
+++ b/src/app/[orgId]/settings/resources/create/page.tsx
@@ -73,12 +73,14 @@ const baseResourceFormSchema = z.object({
 
 const httpResourceFormSchema = z.object({
     domainId: z.string().optional(),
-    subdomain: z.string().optional()
+    subdomain: subdomainSchema.optional()
 });
 
 const tcpUdpResourceFormSchema = z.object({
     protocol: z.string(),
-    proxyPort: z.number().int().min(1).max(65535)
+    proxyPort: z.number().int().min(1).max(65535),
+    domainId: z.string().optional(),
+    subdomain: subdomainSchema.optional()
 });
 
 type BaseResourceFormValues = z.infer<typeof baseResourceFormSchema>;
@@ -144,7 +146,9 @@ export default function Page() {
         resolver: zodResolver(tcpUdpResourceFormSchema),
         defaultValues: {
             protocol: "tcp",
-            proxyPort: undefined
+            proxyPort: undefined,
+            domainId: undefined,
+            subdomain: undefined
         }
     });
 
@@ -163,16 +167,18 @@ export default function Page() {
 
             if (isHttp) {
                 const httpData = httpForm.getValues();
-                    Object.assign(payload, {
-                        subdomain: httpData.subdomain,
-                        domainId: httpData.domainId,
-                        protocol: "tcp",
-                    });
+                Object.assign(payload, {
+                    subdomain: httpData.subdomain,
+                    domainId: httpData.domainId,
+                    protocol: "tcp"
+                });
             } else {
                 const tcpUdpData = tcpUdpForm.getValues();
                 Object.assign(payload, {
                     protocol: tcpUdpData.protocol,
-                    proxyPort: tcpUdpData.proxyPort
+                    proxyPort: tcpUdpData.proxyPort,
+                    domainId: tcpUdpData.domainId,
+                    subdomain: tcpUdpData.subdomain
                 });
             }
 
@@ -267,6 +273,7 @@ export default function Page() {
                     setBaseDomains(domains);
                     if (domains.length) {
                         httpForm.setValue("domainId", domains[0].domainId);
+                        tcpUdpForm.setValue("domainId", domains[0].domainId);
                     }
                 }
             };
@@ -511,12 +518,43 @@ export default function Page() {
                                         </SettingsSectionDescription>
                                     </SettingsSectionHeader>
                                     <SettingsSectionBody>
+                                        <DomainPicker
+                                            orgId={orgId as string}
+                                            onDomainChange={(res) => {
+                                                tcpUdpForm.setValue(
+                                                    "subdomain",
+                                                    res.subdomain
+                                                );
+                                                tcpUdpForm.setValue(
+                                                    "domainId",
+                                                    res.domainId
+                                                );
+                                            }}
+                                        />
                                         <SettingsSectionForm>
                                             <Form {...tcpUdpForm}>
                                                 <form
                                                     className="space-y-4"
                                                     id="tcp-udp-settings-form"
                                                 >
+                                                    <FormField
+                                                        control={tcpUdpForm.control}
+                                                        name="subdomain"
+                                                        render={({ field }) => (
+                                                            <FormItem>
+                                                                <FormLabel>
+                                                                    {t("subdomain")}
+                                                                </FormLabel>
+                                                                <FormControl>
+                                                                    <Input {...field} />
+                                                                </FormControl>
+                                                                <FormMessage />
+                                                                <FormDescription>
+                                                                    {t("subdomnainDescription")}
+                                                                </FormDescription>
+                                                            </FormItem>
+                                                        )}
+                                                    />
                                                     <Controller
                                                         control={
                                                             tcpUdpForm.control


### PR DESCRIPTION
## Summary
- show domain picker and subdomain field when creating RAW resources
- send `domainId` and `subdomain` for raw resources
- allow editing domain for non‑HTTP resources in general settings

## Testing
- `npm ci`
- `npm run db:sqlite:generate`
- `npm run db:sqlite:push`
- `make build-sqlite` *(fails: `docker` not found)*
- `make build-pg` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884df70bfdc83259c9d62fa512bc7bb