### PR TITLE
Add doc about Traefik entryPoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Pangolin is a self-hosted tunneled reverse proxy server with identity and access
 - Built-in support for any WireGuard client.
 - Automated **SSL certificates** (https) via [LetsEncrypt](https://letsencrypt.org/).
 - Support for HTTP/HTTPS and **raw TCP/UDP services**.
+- Each TCP/UDP port must be declared as an `entryPoint` in `config/traefik/traefik_config.yml`. See [docs/traefik-entrypoints.md](./docs/traefik-entrypoints.md).
+- Multiple TCP services can share the same port when using SNI.
 - Raw TCP/UDP resources no longer accept a `subdomain` field.
 - Load balancing.
 - Extend functionality with existing [Traefik](https://github.com/traefik/traefik) plugins, such as [CrowdSec](https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin) and [Geoblock](https://github.com/PascalMinder/geoblock).

--- a/docs/traefik-entrypoints.md
+++ b/docs/traefik-entrypoints.md
@@ -1,0 +1,19 @@
+# Traefik EntryPoints
+
+Pangolin uses Traefik as its reverse proxy. Each TCP or UDP port that you want to expose must be declared as an `entryPoint` in `config/traefik/traefik_config.yml`.
+
+## Declaring Ports
+
+Edit `config/traefik/traefik_config.yml` and add the desired port under the `entryPoints` section. The name of the entryPoint should follow the pattern `<protocol>-<port>`. For example, to expose port `443` for TCP you would add:
+
+```yaml
+entryPoints:
+  tcp-443:
+    address: ":443"
+```
+
+After declaring the entryPoint, resources using this port can reference it automatically.
+
+## Multiple TCP Services on One Port
+
+When using SNI (Server Name Indication), Pangolin can now host multiple TCP services on the same port. Each service is routed based on the requested host name, allowing several TLS-enabled applications to share a single port.


### PR DESCRIPTION
## Summary
- document how to declare TCP/UDP ports as entryPoints
- show example snippet for adding a TCP port
- note support for multiple TCP services on a single port via SNI

## Testing
- `npm ci`
- `make build-sqlite` *(fails: docker not found)*
- `make build-pg` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e845217883258e4b47cf8a8fe879