### PR TITLE
Update encryption to AES-256-GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ We want to hear your feature requests! Add them to the [discussion board](https:
 
 Pangolin is dual licensed under the AGPL-3 and the Fossorial Commercial license. For inquiries about commercial licensing, please contact us at [numbat@fossorial.io](mailto:numbat@fossorial.io).
 
+## Migrating Encrypted Data
+
+`server/lib/crypto.ts` now uses AES-256-GCM with a unique IV. Existing values
+encrypted with the previous scheme will need to be re-encrypted. To migrate:
+
+1. Checkout the commit before this change and run a small script to read each
+   secret from the database using the old `decrypt` function.
+2. Upgrade to the new version and reinsert the values using the updated
+   `encrypt` function.
+
+Values that are not re-encrypted will fail to decrypt after upgrading.
+
 ## Contributions
 
 Looking for something to contribute? Take a look at issues marked with [help wanted](https://github.com/fosrl/pangolin/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22).

--- a/server/lib/crypto.ts
+++ b/server/lib/crypto.ts
@@ -1,12 +1,35 @@
-import CryptoJS from "crypto-js";
+import {
+    createCipheriv,
+    createDecipheriv,
+    randomBytes,
+    createHash
+} from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12; // 96 bits
+
+function getKey(key: string): Buffer {
+    return createHash("sha256").update(key).digest();
+}
 
 export function encrypt(value: string, key: string): string {
-    const ciphertext = CryptoJS.AES.encrypt(value, key).toString();
-    return ciphertext;
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, getKey(key), iv);
+    const encrypted = Buffer.concat([
+        cipher.update(value, "utf8"),
+        cipher.final()
+    ]);
+    const tag = cipher.getAuthTag();
+    return Buffer.concat([iv, tag, encrypted]).toString("base64");
 }
 
 export function decrypt(encryptedValue: string, key: string): string {
-    const bytes = CryptoJS.AES.decrypt(encryptedValue, key);
-    const originalText = bytes.toString(CryptoJS.enc.Utf8);
-    return originalText;
+    const data = Buffer.from(encryptedValue, "base64");
+    const iv = data.subarray(0, IV_LENGTH);
+    const tag = data.subarray(IV_LENGTH, IV_LENGTH + 16);
+    const text = data.subarray(IV_LENGTH + 16);
+    const decipher = createDecipheriv(ALGORITHM, getKey(key), iv);
+    decipher.setAuthTag(tag);
+    const decrypted = Buffer.concat([decipher.update(text), decipher.final()]);
+    return decrypted.toString("utf8");
 }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
- switch `server/lib/crypto.ts` to Node's crypto module using AES‑256‑GCM
- prepend a random IV to the ciphertext and store the auth tag
- document how to migrate existing encrypted values

## How to test?
- `npm run build:sqlite` *(fails: `next` not found after cleaning dependencies)*
- `make build-sqlite` *(fails: docker missing)*
- `make build-pg` *(fails: docker missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a79a242bc8325823d8f5a8d90a7cf