### PR TITLE
Update Traefik TLS verification option

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -27,6 +27,8 @@ server:
 traefik:
     http_entrypoint: "web"
     https_entrypoint: "websecure"
+    # Set to true if using self-signed certificates for upstream services
+    insecure_skip_verify: false
 
 gerbil:
     start_port: 51820

--- a/install/config/traefik/traefik_config.yml
+++ b/install/config/traefik/traefik_config.yml
@@ -45,4 +45,4 @@ entryPoints:
         certResolver: "letsencrypt"
 
 serversTransport:
-  insecureSkipVerify: true
+  insecureSkipVerify: false

--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -130,7 +130,8 @@ export const configSchema = z
                 https_entrypoint: z.string().optional().default("websecure"),
                 additional_middlewares: z.array(z.string()).optional(),
                 cert_resolver: z.string().optional().default("letsencrypt"),
-                prefer_wildcard_cert: z.boolean().optional().default(false)
+                prefer_wildcard_cert: z.boolean().optional().default(false),
+                insecure_skip_verify: z.boolean().optional().default(false)
             })
             .optional()
             .default({}),

--- a/server/routers/traefik/getTraefikConfig.ts
+++ b/server/routers/traefik/getTraefikConfig.ts
@@ -355,9 +355,11 @@ export async function traefikConfigProvider(
                     }
                     config_output.http.serversTransports![transportName] = {
                         serverName: resource.tlsServerName,
-                        //unfortunately the following needs to be set. traefik doesn't merge the default serverTransport settings
-                        // if defined in the static config and here. if not set, self-signed certs won't work
-                        insecureSkipVerify: true
+                        // unfortunately the following needs to be set. Traefik doesn't merge the default serversTransport settings
+                        // if defined in the static config and here. Use the configuration option to override when needed.
+                        insecureSkipVerify:
+                            config.getRawConfig().traefik.insecure_skip_verify ??
+                            false
                     };
                     config_output.http.services![
                         serviceName


### PR DESCRIPTION
## Summary
- set insecureSkipVerify to `false` in default Traefik config
- expose `traefik.insecure_skip_verify` configuration option
- respect the option when generating dynamic configs
- document the new option in `config.example.yml`

## Testing
- `make build-sqlite` *(fails: docker not found)*
- `make build-pg` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a79a1ac74832582a7801af1209a77