### PR TITLE
Increase argon2 password cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ If interested, [contact us](mailto:numbat@fossorial.io).
 
 We want to hear your feature requests! Add them to the [discussion board](https://github.com/orgs/fosrl/discussions/categories/feature-requests).
 
+## Password Hashing
+
+Pangolin uses Argon2id to securely hash secrets. The default configuration
+balances security with server performance:
+
+```
+memoryCost: 65536
+timeCost: 3
+outputLen: 32
+parallelism: 1
+```
+
+You can adjust these values in `server/auth/password.ts` if your hardware
+requires less intensive hashing.
+
 ## Licensing
 
 Pangolin is dual licensed under the AGPL-3 and the Fossorial Commercial license. For inquiries about commercial licensing, please contact us at [numbat@fossorial.io](mailto:numbat@fossorial.io).

--- a/server/auth/password.ts
+++ b/server/auth/password.ts
@@ -5,8 +5,8 @@ export async function verifyPassword(
     hash: string,
 ): Promise<boolean> {
     const validPassword = await verify(hash, password, {
-        memoryCost: 19456,
-        timeCost: 2,
+        memoryCost: 65536,
+        timeCost: 3,
         outputLen: 32,
         parallelism: 1,
     });
@@ -15,8 +15,8 @@ export async function verifyPassword(
 
 export async function hashPassword(password: string): Promise<string> {
     const passwordHash = await hash(password, {
-        memoryCost: 19456,
-        timeCost: 2,
+        memoryCost: 65536,
+        timeCost: 3,
         outputLen: 32,
         parallelism: 1,
     });


### PR DESCRIPTION
## Summary
- raise argon2 `memoryCost` to 65536 and `timeCost` to 3
- document the new default password hashing settings

## Testing
- `npm ci`
- `npm run db:sqlite:generate`
- `npm run db:sqlite:push`
- `npm run build:sqlite` *(fails: Type error in Next.js build)*
- `npm run build:cli`
- `make build-sqlite` *(fails: `docker` not found)*
- `make build-pg` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a79a6f8bc8325a9feb0a3be982430