### PR TITLE
Add startup warning for default server secret

### DIFF
--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -96,6 +96,12 @@ export class Config {
             : "false";
 
         this.rawConfig = parsedConfig;
+
+        if (this.rawConfig.server.secret === "your_secret_key_here") {
+            console.log(
+                "WARNING: You are using the default server secret. Please set a unique value to keep sessions secure."
+            );
+        }
     }
 
     public async initServer() {


### PR DESCRIPTION
## Summary
- warn when `server.secret` is left as the default placeholder

## Testing
- `npm run db:sqlite:generate`
- `npm run db:sqlite:push`
- `npm run build:sqlite`
- `npm run build:cli`
- `make build-sqlite` *(fails: docker not found)*
- `make build-pg` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aaa2c0e58832594c586ece2bacd5c