### PR TITLE
Add security pack feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Pangolin is a self-hosted tunneled reverse proxy server with identity and access
 - Multiple TCP services can share the same port when using SNI.
 - Raw TCP/UDP resources no longer accept a `subdomain` field.
 - Load balancing.
+- Optional firewall protections via the Security Pack. See [docs/security-pack.md](./docs/security-pack.md).
 - Extend functionality with existing [Traefik](https://github.com/traefik/traefik) plugins, such as [CrowdSec](https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin) and [Geoblock](https://github.com/PascalMinder/geoblock).
     - **Automatically install and configure Crowdsec via Pangolin's installer script.**
 - Attach as many sites to the central server as you wish.

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -40,6 +40,9 @@ rate_limits:
     global:
         window_minutes: 1
         max_requests: 500
+security_pack:
+    syn_flood_protection: false
+    icmp_rate_limit: 10
 
 flags:
     require_email_verification: false

--- a/docs/security-pack.md
+++ b/docs/security-pack.md
@@ -1,0 +1,18 @@
+# Security Pack
+
+The Security Pack provides optional firewall protections that can be enabled from `config.yml` or the web interface.
+
+## Options
+
+- **SYN Flood Protection** – Adds iptables rules to mitigate SYN flood attacks.
+- **ICMP Rate Limit** – Limits the rate of ICMP packets accepted per second.
+
+Edit `config/config.yml` under the `security_pack` section:
+
+```yaml
+security_pack:
+    syn_flood_protection: false
+    icmp_rate_limit: 10
+```
+
+After adjusting these settings restart the server or use the API endpoints under `/security` to apply changes at runtime.

--- a/messages/cs-CZ.json
+++ b/messages/cs-CZ.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "License",
     "sidebarClients": "Clients",
     "sidebarDomains": "Domains",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Enable Docker Socket",
     "enableDockerSocketDescription": "Enable Docker Socket discovery for populating container information. Socket path must be provided to Newt.",
     "enableDockerSocketLink": "Learn More",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "DNS changes may take some time to propagate across the internet. This can take anywhere from a few minutes to 48 hours, depending on your DNS provider and TTL settings.",
     "resourcePortRequired": "Port number is required for non-HTTP resources",
     "resourcePortNotAllowed": "Port number should not be set for HTTP resources"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Lizenz",
     "sidebarClients": "Kunden",
     "sidebarDomains": "Domains",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Docker Socket aktivieren",
     "enableDockerSocketDescription": "Docker Socket-Erkennung aktivieren, um Container-Informationen zu befüllen. Socket-Pfad muss Newt bereitgestellt werden.",
     "enableDockerSocketLink": "Mehr erfahren",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "Es kann einige Zeit dauern, bis DNS-Änderungen im Internet verbreitet werden. Dies kann je nach Ihrem DNS-Provider und den TTL-Einstellungen von einigen Minuten bis zu 48 Stunden dauern.",
     "resourcePortRequired": "Portnummer ist für nicht-HTTP-Ressourcen erforderlich",
     "resourcePortNotAllowed": "Portnummer sollte für HTTP-Ressourcen nicht gesetzt werden"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "License",
     "sidebarClients": "Clients",
     "sidebarDomains": "Domains",
+    "sidebarSecurity": "Security",
     "enableDockerSocket": "Enable Docker Socket",
     "enableDockerSocketDescription": "Enable Docker Socket discovery for populating container information. Socket path must be provided to Newt.",
     "enableDockerSocketLink": "Learn More",
@@ -1275,4 +1276,8 @@
     "createDomainDnsPropagationDescription": "DNS changes may take some time to propagate across the internet. This can take anywhere from a few minutes to 48 hours, depending on your DNS provider and TTL settings.",
     "resourcePortRequired": "Port number is required for non-HTTP resources",
     "resourcePortNotAllowed": "Port number should not be set for HTTP resources"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Licencia",
     "sidebarClients": "Clientes",
     "sidebarDomains": "Dominios",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Habilitar conector Docker",
     "enableDockerSocketDescription": "Habilitar el descubrimiento de Docker Socket para completar la información del contenedor. La ruta del socket debe proporcionarse a Newt.",
     "enableDockerSocketLink": "Saber más",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "Los cambios de DNS pueden tardar un tiempo en propagarse a través de internet. Esto puede tardar desde unos pocos minutos hasta 48 horas, dependiendo de tu proveedor de DNS y la configuración de TTL.",
     "resourcePortRequired": "Se requiere número de puerto para recursos no HTTP",
     "resourcePortNotAllowed": "El número de puerto no debe establecerse para recursos HTTP"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Licence",
     "sidebarClients": "Clients",
     "sidebarDomains": "Domaines",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Activer Docker Socket",
     "enableDockerSocketDescription": "Activer la découverte Docker Socket pour remplir les informations du conteneur. Le chemin du socket doit être fourni à Newt.",
     "enableDockerSocketLink": "En savoir plus",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "Les modifications DNS peuvent mettre du temps à se propager sur internet. Cela peut prendre de quelques minutes à 48 heures selon votre fournisseur DNS et les réglages TTL.",
     "resourcePortRequired": "Le numéro de port est requis pour les ressources non-HTTP",
     "resourcePortNotAllowed": "Le numéro de port ne doit pas être défini pour les ressources HTTP"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Licenza",
     "sidebarClients": "Clienti",
     "sidebarDomains": "Domini",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Abilita Docker Socket",
     "enableDockerSocketDescription": "Abilita il rilevamento Docker Socket per popolare le informazioni del contenitore. Il percorso del socket deve essere fornito a Newt.",
     "enableDockerSocketLink": "Scopri di più",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "Le modifiche DNS possono richiedere del tempo per propagarsi in Internet. Questo può richiedere da pochi minuti a 48 ore, a seconda del tuo provider DNS e delle impostazioni TTL.",
     "resourcePortRequired": "Numero di porta richiesto per risorse non-HTTP",
     "resourcePortNotAllowed": "Il numero di porta non deve essere impostato per risorse HTTP"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "라이선스",
     "sidebarClients": "클라이언트",
     "sidebarDomains": "도메인",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Docker 소켓 활성화",
     "enableDockerSocketDescription": "컨테이너 정보를 채우기 위해 Docker 소켓 검색을 활성화합니다. 소켓 경로는 Newt에 제공되어야 합니다.",
     "enableDockerSocketLink": "자세히 알아보기",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "DNS 변경 사항은 인터넷 전체에 전파되는 데 시간이 걸립니다. DNS 제공자와 TTL 설정에 따라 몇 분에서 48시간까지 걸릴 수 있습니다.",
     "resourcePortRequired": "HTTP 리소스가 아닌 경우 포트 번호가 필요합니다",
     "resourcePortNotAllowed": "HTTP 리소스에 대해 포트 번호를 설정하지 마세요"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Licentie",
     "sidebarClients": "Cliënten",
     "sidebarDomains": "Domeinen",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Docker Socket inschakelen",
     "enableDockerSocketDescription": "Docker Socket-ontdekking inschakelen voor het invullen van containerinformatie. Socket-pad moet aan Newt worden verstrekt.",
     "enableDockerSocketLink": "Meer informatie",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "DNS-wijzigingen kunnen enige tijd duren om over het internet te worden verspreid. Dit kan enkele minuten tot 48 uur duren, afhankelijk van je DNS-provider en TTL-instellingen.",
     "resourcePortRequired": "Poortnummer is vereist voor niet-HTTP-bronnen",
     "resourcePortNotAllowed": "Poortnummer mag niet worden ingesteld voor HTTP-bronnen"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Licencja",
     "sidebarClients": "Klienci",
     "sidebarDomains": "Domeny",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Włącz gniazdo dokera",
     "enableDockerSocketDescription": "Włącz wykrywanie Docker Socket w celu wypełnienia informacji o kontenerach. Ścieżka gniazda musi być dostarczona do Newt.",
     "enableDockerSocketLink": "Dowiedz się więcej",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "Zmiany DNS mogą zająć trochę czasu na rozpropagowanie się w Internecie. Może to potrwać od kilku minut do 48 godzin, w zależności od dostawcy DNS i ustawień TTL.",
     "resourcePortRequired": "Numer portu jest wymagany dla zasobów non-HTTP",
     "resourcePortNotAllowed": "Numer portu nie powinien być ustawiony dla zasobów HTTP"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Tipo:",
     "sidebarClients": "Clientes",
     "sidebarDomains": "Domínios",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Habilitar Docker Socket",
     "enableDockerSocketDescription": "Ativar a descoberta do Docker Socket para preencher informações do contêiner. O caminho do socket deve ser fornecido ao Newt.",
     "enableDockerSocketLink": "Saiba mais",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "Alterações no DNS podem levar algum tempo para se propagar pela internet. Pode levar de alguns minutos a 48 horas, dependendo do seu provedor de DNS e das configurações de TTL.",
     "resourcePortRequired": "Número da porta é obrigatório para recursos não-HTTP",
     "resourcePortNotAllowed": "Número da porta não deve ser definido para recursos HTTP"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Лицензия",
     "sidebarClients": "Clients",
     "sidebarDomains": "Domains",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Включить Docker Socket",
     "enableDockerSocketDescription": "Включить обнаружение Docker Socket для заполнения информации о контейнерах. Путь к сокету должен быть предоставлен Newt.",
     "enableDockerSocketLink": "Узнать больше",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "DNS changes may take some time to propagate across the internet. This can take anywhere from a few minutes to 48 hours, depending on your DNS provider and TTL settings.",
     "resourcePortRequired": "Port number is required for non-HTTP resources",
     "resourcePortNotAllowed": "Port number should not be set for HTTP resources"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "Lisans",
     "sidebarClients": "Müşteriler",
     "sidebarDomains": "Alan Adları",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "Docker Soketi Etkinleştir",
     "enableDockerSocketDescription": "Konteyner bilgilerini doldurmak için Docker Socket keşfini etkinleştirin. Socket yolu Newt'e sağlanmalıdır.",
     "enableDockerSocketLink": "Daha fazla bilgi",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "DNS değişikliklerinin internet genelinde yayılması zaman alabilir. DNS sağlayıcınız ve TTL ayarlarına bağlı olarak bu birkaç dakika ile 48 saat arasında değişebilir.",
     "resourcePortRequired": "HTTP dışı kaynaklar için bağlantı noktası numarası gereklidir",
     "resourcePortNotAllowed": "HTTP kaynakları için bağlantı noktası numarası ayarlanmamalı"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1096,6 +1096,7 @@
     "sidebarLicense": "证书",
     "sidebarClients": "客户",
     "sidebarDomains": "域",
+    "sidebarSecurity": "Security"
     "enableDockerSocket": "启用停靠套接字",
     "enableDockerSocketDescription": "启用 Docker Socket 发现以填充容器信息。必须向 Newt 提供 Socket 路径。",
     "enableDockerSocketLink": "了解更多",
@@ -1274,4 +1275,8 @@
     "createDomainDnsPropagationDescription": "DNS 更改可能需要一些时间才能在互联网上传播。这可能需要从几分钟到 48 小时，具体取决于您的 DNS 提供商和 TTL 设置。",
     "resourcePortRequired": "非 HTTP 资源必须输入端口号",
     "resourcePortNotAllowed": "HTTP 资源不应设置端口号"
+    "securityPack": "Security Pack",
+    "securityPackDescription": "Configure firewall protections.",
+    "synFloodProtection": "SYN Flood Protection",
+    "icmpRateLimit": "ICMP Rate Limit"
 }

--- a/server/db/pg/schema.ts
+++ b/server/db/pg/schema.ts
@@ -407,6 +407,19 @@ export const resourceRules = pgTable("resourceRules", {
     value: varchar("value").notNull()
 });
 
+export const securityPackRules = pgTable("securityPackRules", {
+    ruleId: serial("ruleId").primaryKey(),
+    name: varchar("name").notNull(),
+    value: integer("value"),
+    enabled: boolean("enabled").notNull().default(true)
+});
+
+export const globalThrottles = pgTable("globalThrottles", {
+    throttleId: serial("throttleId").primaryKey(),
+    name: varchar("name").notNull(),
+    value: integer("value").notNull()
+});
+
 export const supporterKey = pgTable("supporterKey", {
     keyId: serial("keyId").primaryKey(),
     key: varchar("key").notNull(),
@@ -629,3 +642,5 @@ export type OlmSession = InferSelectModel<typeof olmSessions>;
 export type UserClient = InferSelectModel<typeof userClients>;
 export type RoleClient = InferSelectModel<typeof roleClients>;
 export type OrgDomains = InferSelectModel<typeof orgDomains>;
+export type SecurityPackRule = InferSelectModel<typeof securityPackRules>;
+export type GlobalThrottle = InferSelectModel<typeof globalThrottles>;

--- a/server/db/sqlite/schema.ts
+++ b/server/db/sqlite/schema.ts
@@ -536,6 +536,19 @@ export const resourceRules = sqliteTable("resourceRules", {
     value: text("value").notNull()
 });
 
+export const securityPackRules = sqliteTable("securityPackRules", {
+    ruleId: integer("ruleId").primaryKey({ autoIncrement: true }),
+    name: text("name").notNull(),
+    value: integer("value"),
+    enabled: integer("enabled", { mode: "boolean" }).notNull().default(true)
+});
+
+export const globalThrottles = sqliteTable("globalThrottles", {
+    throttleId: integer("throttleId").primaryKey({ autoIncrement: true }),
+    name: text("name").notNull(),
+    value: integer("value").notNull()
+});
+
 export const supporterKey = sqliteTable("supporterKey", {
     keyId: integer("keyId").primaryKey({ autoIncrement: true }),
     key: text("key").notNull(),
@@ -674,3 +687,5 @@ export type ApiKey = InferSelectModel<typeof apiKeys>;
 export type ApiKeyAction = InferSelectModel<typeof apiKeyActions>;
 export type ApiKeyOrg = InferSelectModel<typeof apiKeyOrg>;
 export type OrgDomains = InferSelectModel<typeof orgDomains>;
+export type SecurityPackRule = InferSelectModel<typeof securityPackRules>;
+export type GlobalThrottle = InferSelectModel<typeof globalThrottles>;

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -95,6 +95,13 @@ export class Config {
             ? "true"
             : "false";
 
+        process.env.SECURITY_PACK_SYN_FLOOD = parsedConfig.security_pack?.syn_flood_protection
+            ? "true"
+            : "false";
+        process.env.SECURITY_PACK_ICMP_RATE = String(
+            parsedConfig.security_pack?.icmp_rate_limit ?? 0
+        );
+
         this.rawConfig = parsedConfig;
     }
 

--- a/server/lib/index.ts
+++ b/server/lib/index.ts
@@ -1,1 +1,2 @@
 export * from "./response";
+export * from "./securityPack";

--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -208,6 +208,13 @@ export const configSchema = z
             })
             .optional()
             .default({}),
+        security_pack: z
+            .object({
+                syn_flood_protection: z.boolean().optional().default(false),
+                icmp_rate_limit: z.number().int().nonnegative().optional().default(0)
+            })
+            .optional()
+            .default({}),
         email: z
             .object({
                 smtp_host: z.string().optional(),

--- a/server/lib/securityPack.ts
+++ b/server/lib/securityPack.ts
@@ -1,0 +1,73 @@
+import { exec } from "child_process";
+import util from "util";
+import logger from "@server/logger";
+import config from "@server/lib/config";
+
+const execAsync = util.promisify(exec);
+
+export async function enableSynFloodProtection() {
+    try {
+        await execAsync(
+            "iptables -A INPUT -p tcp --syn -m limit --limit 1/s --limit-burst 4 -j RETURN"
+        );
+        logger.info("SYN flood protection enabled");
+    } catch (e) {
+        logger.warn("Failed to enable SYN flood protection", e);
+    }
+}
+
+export async function disableSynFloodProtection() {
+    try {
+        await execAsync(
+            "iptables -D INPUT -p tcp --syn -m limit --limit 1/s --limit-burst 4 -j RETURN"
+        );
+        logger.info("SYN flood protection disabled");
+    } catch (e) {
+        logger.warn("Failed to disable SYN flood protection", e);
+    }
+}
+
+export async function setIcmpRateLimit(rate: number) {
+    try {
+        await execAsync(
+            `iptables -A INPUT -p icmp -m limit --limit ${rate}/s -j ACCEPT`
+        );
+        logger.info(`ICMP rate limited to ${rate}/s`);
+    } catch (e) {
+        logger.warn("Failed to set ICMP rate limit", e);
+    }
+}
+
+export async function clearIcmpRateLimit() {
+    try {
+        await execAsync(
+            "iptables -D INPUT -p icmp -m limit --limit 1/s -j ACCEPT"
+        );
+        logger.info("ICMP rate limiting cleared");
+    } catch (e) {
+        logger.warn("Failed to clear ICMP rate limit", e);
+    }
+}
+
+export async function applySecurityPack() {
+    const cfg = config.getRawConfig().security_pack || {};
+    if (cfg.syn_flood_protection) {
+        await enableSynFloodProtection();
+    } else {
+        await disableSynFloodProtection();
+    }
+
+    if (cfg.icmp_rate_limit && cfg.icmp_rate_limit > 0) {
+        await setIcmpRateLimit(cfg.icmp_rate_limit);
+    } else {
+        await clearIcmpRateLimit();
+    }
+}
+
+export function getSecurityStatus() {
+    const cfg = config.getRawConfig().security_pack || {};
+    return {
+        syn_flood_protection: !!cfg.syn_flood_protection,
+        icmp_rate_limit: cfg.icmp_rate_limit ?? 0
+    };
+}

--- a/server/routers/external.ts
+++ b/server/routers/external.ts
@@ -14,6 +14,7 @@ import * as accessToken from "./accessToken";
 import * as idp from "./idp";
 import * as license from "./license";
 import * as apiKeys from "./apiKeys";
+import * as security from "./security";
 import HttpCode from "@server/types/HttpCode";
 import {
     verifyAccessTokenAccess,
@@ -671,6 +672,17 @@ authenticated.post(
     "/license/recheck",
     verifyUserIsServerAdmin,
     license.recheckStatus
+);
+
+authenticated.get(
+    "/security",
+    verifyUserIsServerAdmin,
+    security.getStatus
+);
+authenticated.post(
+    "/security",
+    verifyUserIsServerAdmin,
+    security.updateSecurity
 );
 
 authenticated.get(

--- a/server/routers/security/index.ts
+++ b/server/routers/security/index.ts
@@ -1,0 +1,1 @@
+export * from "./routes";

--- a/server/routers/security/routes.ts
+++ b/server/routers/security/routes.ts
@@ -1,0 +1,70 @@
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { response as sendResponse } from "@server/lib";
+import HttpCode from "@server/types/HttpCode";
+import createHttpError from "http-errors";
+import logger from "@server/logger";
+import { fromError } from "zod-validation-error";
+import {
+    applySecurityPack,
+    getSecurityStatus,
+} from "@server/lib/securityPack";
+
+const updateSchema = z
+    .object({
+        syn_flood_protection: z.boolean().optional(),
+        icmp_rate_limit: z.number().int().nonnegative().optional(),
+    })
+    .strict();
+
+export async function getStatus(
+    req: Request,
+    res: Response,
+    next: NextFunction
+) {
+    try {
+        const status = getSecurityStatus();
+        return sendResponse(res, {
+            data: status,
+            success: true,
+            error: false,
+            message: "Status",
+            status: HttpCode.OK,
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(createHttpError(HttpCode.INTERNAL_SERVER_ERROR));
+    }
+}
+
+export async function updateSecurity(
+    req: Request,
+    res: Response,
+    next: NextFunction
+) {
+    try {
+        const parsed = updateSchema.safeParse(req.body);
+        if (!parsed.success) {
+            return next(createHttpError(HttpCode.BAD_REQUEST, fromError(parsed.error)));
+        }
+        // merge into config raw (in-memory)
+        const cfg = {
+            ...getSecurityStatus(),
+            ...parsed.data,
+        };
+        // update config in memory
+        const raw = require("@server/lib/config").config.getRawConfig();
+        raw.security_pack = cfg;
+        await applySecurityPack();
+        return sendResponse(res, {
+            data: cfg,
+            success: true,
+            error: false,
+            message: "Updated",
+            status: HttpCode.OK,
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(createHttpError(HttpCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/server/setup/migrationsPg.ts
+++ b/server/setup/migrationsPg.ts
@@ -7,6 +7,7 @@ import path from "path";
 import m1 from "./scriptsPg/1.6.0";
 import m2 from "./scriptsPg/1.7.0";
 import m3 from "./scriptsPg/1.8.0";
+import m4 from "./scriptsPg/1.9.0";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -15,7 +16,8 @@ import m3 from "./scriptsPg/1.8.0";
 const migrations = [
     { version: "1.6.0", run: m1 },
     { version: "1.7.0", run: m2 },
-    { version: "1.8.0", run: m3 }
+    { version: "1.8.0", run: m3 },
+    { version: "1.9.0", run: m4 }
     // Add new migrations here as they are created
 ] as {
     version: string;

--- a/server/setup/migrationsSqlite.ts
+++ b/server/setup/migrationsSqlite.ts
@@ -24,6 +24,7 @@ import m20 from "./scriptsSqlite/1.5.0";
 import m21 from "./scriptsSqlite/1.6.0";
 import m22 from "./scriptsSqlite/1.7.0";
 import m23 from "./scriptsSqlite/1.8.0";
+import m24 from "./scriptsSqlite/1.9.0";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -48,6 +49,7 @@ const migrations = [
     { version: "1.6.0", run: m21 },
     { version: "1.7.0", run: m22 },
     { version: "1.8.0", run: m23 },
+    { version: "1.9.0", run: m24 },
     // Add new migrations here as they are created
 ] as const;
 

--- a/server/setup/scriptsPg/1.9.0.ts
+++ b/server/setup/scriptsPg/1.9.0.ts
@@ -1,0 +1,30 @@
+import { db } from "@server/db/pg/driver";
+import { sql } from "drizzle-orm";
+
+const version = "1.9.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    try {
+        await db.execute(sql`
+            CREATE TABLE "securityPackRules" (
+                "ruleId" serial PRIMARY KEY NOT NULL,
+                "name" varchar NOT NULL,
+                "value" integer,
+                "enabled" boolean DEFAULT true NOT NULL
+            );
+            CREATE TABLE "globalThrottles" (
+                "throttleId" serial PRIMARY KEY NOT NULL,
+                "name" varchar NOT NULL,
+                "value" integer NOT NULL
+            );
+        `);
+        console.log(`Migrated database schema`);
+    } catch (e) {
+        console.log("Unable to migrate database schema");
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/server/setup/scriptsSqlite/1.9.0.ts
+++ b/server/setup/scriptsSqlite/1.9.0.ts
@@ -1,0 +1,34 @@
+import { APP_PATH } from "@server/lib/consts";
+import Database from "better-sqlite3";
+import path from "path";
+
+const version = "1.9.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    const location = path.join(APP_PATH, "db", "db.sqlite");
+    const db = new Database(location);
+
+    try {
+        db.exec(`
+            CREATE TABLE 'securityPackRules' (
+                'ruleId' integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                'name' text NOT NULL,
+                'value' integer,
+                'enabled' integer DEFAULT 1 NOT NULL
+            );
+            CREATE TABLE 'globalThrottles' (
+                'throttleId' integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                'name' text NOT NULL,
+                'value' integer NOT NULL
+            );
+        `);
+        console.log(`Migrated database schema`);
+    } catch (e) {
+        console.log("Unable to migrate database schema");
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/src/app/[orgId]/security/page.tsx
+++ b/src/app/[orgId]/security/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useEnvContext } from "@app/hooks/useEnvContext";
+import { createApiClient } from "@app/lib/api";
+import { toast } from "@app/hooks/useToast";
+import {
+    SettingsContainer,
+    SettingsSection,
+    SettingsSectionHeader,
+    SettingsSectionTitle,
+    SettingsSectionDescription,
+    SettingsSectionBody,
+    SettingsSectionForm,
+    SettingsSectionFooter,
+} from "@app/components/Settings";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
+
+export default function SecurityPage({ params }: { params: { orgId: string } }) {
+    const { env } = useEnvContext();
+    const api = createApiClient(useEnvContext());
+    const t = useTranslations();
+    const [synFlood, setSynFlood] = useState(false);
+    const [icmpRate, setIcmpRate] = useState(0);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        async function fetchStatus() {
+            try {
+                const res = await api.get(`/security`);
+                if (res.status === 200) {
+                    setSynFlood(res.data.data.syn_flood_protection);
+                    setIcmpRate(res.data.data.icmp_rate_limit);
+                }
+            } catch (e) {}
+        }
+        fetchStatus();
+    }, []);
+
+    async function save() {
+        setLoading(true);
+        try {
+            await api.post(`/security`, {
+                syn_flood_protection: synFlood,
+                icmp_rate_limit: icmpRate,
+            });
+            toast({ title: t("settingsSaved") });
+        } catch (e) {
+            toast({ variant: "destructive", title: t("error") });
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <SettingsContainer>
+            <SettingsSection>
+                <SettingsSectionHeader>
+                    <SettingsSectionTitle>
+                        {t("securityPack")}
+                    </SettingsSectionTitle>
+                    <SettingsSectionDescription>
+                        {t("securityPackDescription")}
+                    </SettingsSectionDescription>
+                </SettingsSectionHeader>
+                <SettingsSectionBody>
+                    <SettingsSectionForm>
+                        <div className="flex items-center justify-between">
+                            <label>{t("synFloodProtection")}</label>
+                            <Switch
+                                checked={synFlood}
+                                onCheckedChange={setSynFlood}
+                            />
+                        </div>
+                        <div className="flex items-center justify-between">
+                            <label>{t("icmpRateLimit")}</label>
+                            <Input
+                                value={icmpRate}
+                                type="number"
+                                onChange={(e) => setIcmpRate(Number(e.target.value))}
+                                className="w-24 ml-2"
+                            />
+                        </div>
+                    </SettingsSectionForm>
+                </SettingsSectionBody>
+                <SettingsSectionFooter>
+                    <Button onClick={save} loading={loading}>
+                        {t("saveSettings")}
+                    </Button>
+                </SettingsSectionFooter>
+            </SettingsSection>
+        </SettingsContainer>
+    );
+}

--- a/src/app/navigation.tsx
+++ b/src/app/navigation.tsx
@@ -13,7 +13,8 @@ import {
     TicketCheck,
     User,
     Globe,
-    MonitorUp
+    MonitorUp,
+    Shield
 } from "lucide-react";
 
 export type SidebarNavSection = {
@@ -50,6 +51,11 @@ export const orgNavSections = (
                 title: "sidebarDomains",
                 href: "/{orgId}/settings/domains",
                 icon: <Globe className="h-4 w-4" />
+            },
+            {
+                title: "sidebarSecurity",
+                href: "/{orgId}/security",
+                icon: <Shield className="h-4 w-4" />
             }
         ]
     },


### PR DESCRIPTION
## Summary
- add `security_pack` section to config example
- expose new config fields in `readConfigFile`
- implement firewall helpers in `securityPack.ts`
- provide API routes under `/security`
- add docs on using the security pack and reference it in README
- update database schemas and migrations
- create security settings page in dashboard
- update translations and navigation

## Testing
- `npm run db:sqlite:generate` *(fails: unknown command)*
- `npm run db:sqlite:push` *(fails: Can't find meta/_journal.json)*
- `make build-sqlite` *(fails: docker not found)*
- `make build-pg` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af099dd108325acbe6793467d5901