### PR TITLE
Add configurable rate limit store

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Pangolin is a self-hosted tunneled reverse proxy server with identity and access
 - Raw TCP/UDP resources no longer accept a `subdomain` field.
 - Load balancing.
 - Optional firewall protections via the Security Pack. See [docs/security-pack.md](./docs/security-pack.md).
+- Configurable rate limit store using Redis or the database. See [docs/rate-limit-store.md](./docs/rate-limit-store.md).
 - Extend functionality with existing [Traefik](https://github.com/traefik/traefik) plugins, such as [CrowdSec](https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin) and [Geoblock](https://github.com/PascalMinder/geoblock).
     - **Automatically install and configure Crowdsec via Pangolin's installer script.**
 - Attach as many sites to the central server as you wish.

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -36,7 +36,11 @@ gerbil:
     subnet_group: 100.89.137.0/20
     use_subdomain: true
 
+redis:
+    connection_string: "redis://localhost:6379"
+
 rate_limits:
+    store: "memory"
     global:
         window_minutes: 1
         max_requests: 500

--- a/docs/rate-limit-store.md
+++ b/docs/rate-limit-store.md
@@ -1,0 +1,22 @@
+# Rate Limit Store
+
+Pangolin can persist rate limit counters using Redis or the primary database. By default a memory store is used.
+
+Add a `redis` section and choose the store type in `config.yml`:
+
+```yaml
+redis:
+    connection_string: redis://localhost:6379
+
+rate_limits:
+    store: redis
+```
+
+To use the database instead:
+
+```yaml
+rate_limits:
+    store: database
+```
+
+If the table does not exist it will be created automatically when the server starts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,12 +77,14 @@
                 "oslo": "1.2.1",
                 "pg": "^8.16.2",
                 "qrcode.react": "4.2.0",
+                "rate-limit-redis": "^4.2.1",
                 "react": "19.1.0",
                 "react-dom": "19.1.0",
                 "react-easy-sort": "^1.6.0",
                 "react-hook-form": "7.60.0",
                 "react-icons": "^5.5.0",
                 "rebuild": "0.1.2",
+                "redis": "^4.6.7",
                 "semver": "^7.7.2",
                 "swagger-ui-express": "^5.0.1",
                 "tailwind-merge": "3.3.1",
@@ -3889,6 +3891,71 @@
                 "react": "^18.0 || ^19.0 || ^19.0.0-rc"
             }
         },
+        "node_modules/@redis/bloom": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+            "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@redis/client": "^1.0.0"
+            }
+        },
+        "node_modules/@redis/client": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+            "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+            "license": "MIT",
+            "dependencies": {
+                "cluster-key-slot": "1.1.2",
+                "generic-pool": "3.9.0",
+                "yallist": "4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@redis/client/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
+        },
+        "node_modules/@redis/graph": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+            "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@redis/client": "^1.0.0"
+            }
+        },
+        "node_modules/@redis/json": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+            "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@redis/client": "^1.0.0"
+            }
+        },
+        "node_modules/@redis/search": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+            "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@redis/client": "^1.0.0"
+            }
+        },
+        "node_modules/@redis/time-series": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+            "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@redis/client": "^1.0.0"
+            }
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -6088,6 +6155,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/cmdk": {
@@ -8947,6 +9023,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generic-pool": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+            "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/get-caller-file": {
@@ -14890,6 +14975,18 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/rate-limit-redis": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.2.1.tgz",
+            "integrity": "sha512-JsUsVmRVI6G/XrlYtfGV1NMCbGS/CVYayHkxD5Ism5FaL8qpFHCXbFkUeIi5WJ/onJOKWCgtB/xtCLa6qSXb4g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "peerDependencies": {
+                "express-rate-limit": ">= 6"
+            }
+        },
         "node_modules/raw-body": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -15234,6 +15331,23 @@
             },
             "engines": {
                 "node": ">=0.8.8"
+            }
+        },
+        "node_modules/redis": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+            "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+            "license": "MIT",
+            "workspaces": [
+                "./packages/*"
+            ],
+            "dependencies": {
+                "@redis/bloom": "1.2.0",
+                "@redis/client": "1.6.1",
+                "@redis/graph": "1.1.1",
+                "@redis/json": "1.0.7",
+                "@redis/search": "1.2.0",
+                "@redis/time-series": "1.1.0"
             }
         },
         "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
         "eslint-config-next": "15.3.5",
         "express": "4.21.2",
         "express-rate-limit": "7.5.1",
+        "rate-limit-redis": "^4.2.1",
+        "redis": "^4.6.7",
         "glob": "11.0.3",
         "helmet": "8.1.0",
         "http-errors": "2.0.0",

--- a/server/lib/rateLimitStore.ts
+++ b/server/lib/rateLimitStore.ts
@@ -1,6 +1,94 @@
-import { MemoryStore, Store } from "express-rate-limit";
+import { MemoryStore, Store, Options, ClientRateLimitInfo } from "express-rate-limit";
+import RedisStore from "rate-limit-redis";
+import { createClient } from "redis";
+import { db } from "@server/db";
+import { sql } from "drizzle-orm";
+import config from "@server/lib/config";
+import logger from "@server/logger";
+
+class DatabaseStore implements Store {
+    windowMs = 60_000;
+
+    async init(options: Options) {
+        this.windowMs = options.windowMs ?? this.windowMs;
+        await db.execute(sql`
+            CREATE TABLE IF NOT EXISTS rate_limits (
+                key TEXT PRIMARY KEY,
+                hits INTEGER NOT NULL,
+                reset_at BIGINT NOT NULL
+            )
+        `);
+    }
+
+    async get(key: string): Promise<ClientRateLimitInfo | undefined> {
+        const res: any = await db.execute(sql`
+            SELECT hits, reset_at FROM rate_limits WHERE key = ${key}
+        `);
+        const row = res.rows?.[0] ?? res[0];
+        if (!row) return undefined;
+        if (row.reset_at < Date.now()) {
+            await this.resetKey(key);
+            return undefined;
+        }
+        return { totalHits: row.hits, resetTime: new Date(row.reset_at) };
+    }
+
+    async increment(key: string): Promise<ClientRateLimitInfo> {
+        const now = Date.now();
+        const expire = now + this.windowMs;
+        const existing: any = await db.execute(sql`
+            SELECT hits, reset_at FROM rate_limits WHERE key = ${key}
+        `);
+        const row = existing.rows?.[0] ?? existing[0];
+        if (!row) {
+            await db.execute(sql`
+                INSERT INTO rate_limits (key, hits, reset_at)
+                VALUES (${key}, 1, ${expire})
+            `);
+            return { totalHits: 1, resetTime: new Date(expire) };
+        }
+
+        if (row.reset_at < now) {
+            await db.execute(sql`
+                UPDATE rate_limits SET hits = 1, reset_at = ${expire} WHERE key = ${key}
+            `);
+            return { totalHits: 1, resetTime: new Date(expire) };
+        }
+
+        const hits = row.hits + 1;
+        await db.execute(sql`
+            UPDATE rate_limits SET hits = ${hits} WHERE key = ${key}
+        `);
+        return { totalHits: hits, resetTime: new Date(row.reset_at) };
+    }
+
+    async decrement(key: string) {
+        await db.execute(sql`
+            UPDATE rate_limits SET hits = CASE WHEN hits > 0 THEN hits - 1 ELSE 0 END WHERE key = ${key}
+        `);
+    }
+
+    async resetKey(key: string) {
+        await db.execute(sql`DELETE FROM rate_limits WHERE key = ${key}`);
+    }
+
+    async resetAll() {
+        await db.execute(sql`DELETE FROM rate_limits`);
+    }
+}
 
 export function createStore(): Store {
-    let rateLimitStore: Store = new MemoryStore();
-    return rateLimitStore;
+    const raw = config.getRawConfig();
+
+    if (raw.rate_limits?.store === "redis" && raw.redis?.connection_string) {
+        const client = createClient({ url: raw.redis.connection_string });
+        client.on("error", (err) => logger.error("Redis error", err));
+        return new (RedisStore as any)({ sendCommand: (...args: any[]) => client.sendCommand(args) });
+    }
+
+    if (raw.rate_limits?.store === "database") {
+        return new DatabaseStore();
+    }
+
+    return new MemoryStore();
 }

--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -124,6 +124,11 @@ export const configSchema = z
                     .optional()
             })
             .optional(),
+        redis: z
+            .object({
+                connection_string: z.string()
+            })
+            .optional(),
         traefik: z
             .object({
                 http_entrypoint: z.string().optional().default("web"),
@@ -171,6 +176,10 @@ export const configSchema = z
             }),
         rate_limits: z
             .object({
+                store: z
+                    .enum(["memory", "redis", "database"])
+                    .optional()
+                    .default("memory"),
                 global: z
                     .object({
                         window_minutes: z


### PR DESCRIPTION
## Summary
- support Redis or DB for rate limiting
- show new Redis options in config example
- document rate limit store
- mention new feature in README

## Testing
- `make build-sqlite` *(fails: docker not found)*
- `make build-pg` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b024b85c88325a79fef6ff0706210